### PR TITLE
Fix opencv imread when the fpath contains Chinese

### DIFF
--- a/data/load_data.py
+++ b/data/load_data.py
@@ -36,7 +36,7 @@ class LPRDataLoader(Dataset):
 
     def __getitem__(self, index):
         filename = self.img_paths[index]
-        Image = cv2.imread(filename)
+        Image = cv2.imdecode(np.fromfile(filename,dtype=np.uint8), cv2.IMREAD_COLOR)
         height, width, _ = Image.shape
         if height != self.img_size[1] or width != self.img_size[0]:
             Image = cv2.resize(Image, self.img_size)


### PR DESCRIPTION
opencv 无法读取中文路径下的图片(如Windows系统上）。使用 numpy 读取到内存，然后使用 opencv 解码，实现图片读取。